### PR TITLE
Correct the homepage of the gem

### DIFF
--- a/puppet_facts.gemspec
+++ b/puppet_facts.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version     = PuppetFacts::Version::STRING
   s.authors     = ["Puppet Labs"]
   s.email       = ["modules-dept@puppetlabs.com"]
-  s.homepage    = "http://github.com/puppetlabs/puppet_facts"
+  s.homepage    = "https://github.com/apenney/puppet_facts"
   s.summary     = "Standard facts fixtures for PE and POSS platforms"
   s.description = "Contains facts from many PE and POSS systems"
   s.licenses    = 'Apache-2.0'


### PR DESCRIPTION
Until this is moved to github.com/puppetlabs, the homepage should reflect where the code actually lives.